### PR TITLE
WAI-4011

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -68,6 +68,15 @@ These nodes create high-quality product images for eCommerce workflows.
 | **ShotByText**         | Modifies an image's background by providing a text prompt. Powered by BRIA's ControlNet Background-Generation. |
 | **ShotByImage**        | Modifies an image's background by providing a reference image. Uses BRIA's ControlNet Background-Generation and Image-Prompt. |
 
+## Attribution Node
+
+| Node                          | Description |
+|-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Attribution By Image Node** | This node shares generated images via API for Bria to pay attribution to the data owners who contributed to the generation. Once the images are shared with Bria, Bria calculates the attribution, completes the payment on behalf of the user, and erases the images immediately. This node should be included in any workflow using nodes of Bria’s Models (not necessary for Bria’s API nodes). You can also refer to the [**API documentation**]( https://docs.bria.ai/bria-attribution-service/other/postattributionbyimage) |
+
+
+
+
 # Installation
 There are two methods to install the BRIA ComfyUI API nodes:
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 from .nodes import (EraserNode, GenFillNode, ImageExpansionNode, ReplaceBgNode, RmbgNode, RemoveForegroundNode, ShotByTextNode, ShotByImageNode, TailoredGenNode,
                      TailoredModelInfoNode, Text2ImageBaseNode, Text2ImageFastNode, Text2ImageHDNode, TailoredPortraitNode,
-                     ReimagineNode)
+                     ReimagineNode, AttributionByImageNode)
 # Map the node class to a name used internally by ComfyUI
 NODE_CLASS_MAPPINGS = {
     "BriaEraser": EraserNode,  # Return the class, not an instance
@@ -18,6 +18,7 @@ NODE_CLASS_MAPPINGS = {
     "Text2ImageFastNode": Text2ImageFastNode,
     "Text2ImageHDNode": Text2ImageHDNode,
     "ReimagineNode": ReimagineNode,
+    "AttributionByImageNode":AttributionByImageNode
 }
 # Map the node display name to the one shown in the ComfyUI node interface
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -36,4 +37,5 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "Text2ImageFastNode": "Bria Text2Image Fast",
     "Text2ImageHDNode": "Bria Text2Image HD",
     "ReimagineNode": "Bria Reimagine",
+    "AttributionByImageNode":"Attribution By Image Node"
 }

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -13,3 +13,4 @@ from .text_2_image_base_node import Text2ImageBaseNode
 from .text_2_image_fast_node import Text2ImageFastNode
 from .text_2_image_hd_node import Text2ImageHDNode
 from .reimagine_node import ReimagineNode
+from .attribution_by_image_node import AttributionByImageNode

--- a/nodes/attribution_by_image_node.py
+++ b/nodes/attribution_by_image_node.py
@@ -1,0 +1,66 @@
+import requests
+import torch
+
+from .common import preprocess_image, image_to_base64, poll_status_until_completed
+
+class AttributionByImageNode():
+    @classmethod
+    def INPUT_TYPES(self):
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "model_version": (["2.3", "3.0","3.2"], {"default": "2.3"}),
+                "api_key": ("STRING", {"default": "BRIA_API_TOKEN"}),
+            },              
+        }
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("api_response",)
+    CATEGORY = "API Nodes"
+    FUNCTION = "execute"  # This is the method that will be executed
+
+    def __init__(self):
+        self.api_url = "https://engine.prod.bria-api.com/v2/image/attribution/by_image"
+
+    # Define the execute method as expected by ComfyUI
+    def execute(self, image, model_version, api_key):
+        if api_key.strip() == "" or api_key.strip() == "BRIA_API_TOKEN":
+            raise Exception("Please insert a valid API key.")
+
+        # Check if image is tensor, if so, convert to NumPy array
+        if isinstance(image, torch.Tensor):
+            image = preprocess_image(image)
+
+        # Convert image to base64 for the new API format
+        image_base64 = image_to_base64(image)
+        payload = {
+            "image": image_base64,
+            "model_version": model_version,
+        }
+
+        headers = {
+            "Content-Type": "application/json",
+            "api_token": f"{api_key}"
+        }
+
+        try:
+            response = requests.post(self.api_url, json=payload, headers=headers)
+            
+            if response.status_code == 200 or response.status_code == 202:
+                print('Initial Attribution via Images API request successful, polling for completion...')
+                response_dict = response.json()
+
+                status_url = response_dict.get('status_url')
+                request_id = response_dict.get('request_id')
+                
+                if not status_url:
+                    raise Exception("No status_url returned from API")
+                
+                print(f"Request ID: {request_id}, Status URL: {status_url}")
+                
+                final_response = poll_status_until_completed(status_url, api_key)
+                return (str(final_response.get("result",{}).get("content")),)
+            else:
+                raise Exception(f"Error: API request failed with status code {response.status_code} {response.text}")
+        except Exception as e:
+            raise Exception(f"{e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-bria-api"
 description = "Custom nodes for ComfyUI using BRIA's API."
-version = "2.1.1"
+version = "2.1.2"
 license = {file = "LICENSE"}
 
 [project.urls]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add Attribution By Image node with API integration, update README, and bump version to 2.1.2.
> 
> - **Nodes**:
>   - **New `AttributionByImageNode`**: Implements API call to BRIA Attribution-by-Image (`v2/image/attribution/by_image`) with polling; inputs `image`, `model_version` (2.3/3.0/3.2), `api_key`; returns API response content. Exported and registered in `nodes/__init__.py` and root `__init__.py` mappings/display names.
> - **Docs**:
>   - Add README section for Attribution Node with description and API docs link.
> - **Version**:
>   - Bump package version to `2.1.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d3eef85cadb0bf281cf61d7183f85578821118d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->