### PR TITLE
Versioned User-Agent and consistent headers on all HTTP calls

### DIFF
--- a/nodes/common.py
+++ b/nodes/common.py
@@ -7,8 +7,20 @@ from torchvision.transforms import ToPILImage
 import requests
 import time
 
+from importlib.metadata import PackageNotFoundError, version as _package_version
 
-BRIA_COMFYUI_USER_AGENT = "bria/ComfyUI"
+try:
+    _BRIA_COMFYUI_PACKAGE_VERSION = _package_version("comfyui-bria-api")
+except PackageNotFoundError:
+    _BRIA_COMFYUI_PACKAGE_VERSION = "dev"
+
+BRIA_COMFYUI_USER_AGENT = f"bria/ComfyUI-BRIA-API/{_BRIA_COMFYUI_PACKAGE_VERSION}"
+
+
+def bria_asset_headers() -> dict:
+    """Headers for asset fetches (CDN/S3 URLs) where api_token is not sent."""
+    return {"User-Agent": BRIA_COMFYUI_USER_AGENT}
+
 
 def bria_json_headers(api_token: str) -> dict:
     """Headers for JSON POST requests to Bria API."""
@@ -125,7 +137,7 @@ def process_request(api_url, image, mask, api_key, visual_input_content_moderati
             result_image_url = final_response['result']['image_url']
             
             # Download and process the result image
-            image_response = requests.get(result_image_url)
+            image_response = requests.get(result_image_url, headers=bria_asset_headers())
             result_image = Image.open(io.BytesIO(image_response.content))
             result_image = result_image.convert("RGBA")
             result_image = np.array(result_image).astype(np.float32) / 255.0

--- a/nodes/fibo_edit_node.py
+++ b/nodes/fibo_edit_node.py
@@ -2,6 +2,7 @@ import requests
 import torch
 
 from .common import (
+    bria_asset_headers,
     bria_json_headers,
     image_to_base64,
     poll_status_until_completed,
@@ -149,7 +150,10 @@ class FIBOEditNode:
                 structured_prompt = result.get("structured_prompt", "")
                 used_seed = result.get("seed")
 
-                image_response = requests.get(result_image_url)
+                image_response = requests.get(
+                    result_image_url,
+                    headers=bria_asset_headers(),
+                )
                 result_image = postprocess_image(image_response.content)
 
                 return (result_image, structured_prompt, used_seed)

--- a/nodes/generate_image_lite_node_v2.py
+++ b/nodes/generate_image_lite_node_v2.py
@@ -1,6 +1,7 @@
 import requests
 import torch
 from .common import (
+    bria_asset_headers,
     bria_json_headers,
     image_to_base64,
     normalize_images_input,
@@ -137,7 +138,10 @@ class GenerateImageLiteNodeV2:
                 structured_prompt_result = result.get("structured_prompt", "")
                 used_seed = result.get("seed", seed_values[idx])
 
-                image_response = requests.get(result_image_url)
+                image_response = requests.get(
+                    result_image_url,
+                    headers=bria_asset_headers(),
+                )
                 result_image = postprocess_image(image_response.content)
 
                 batch_results.append(result_image)

--- a/nodes/generate_image_node_v2.py
+++ b/nodes/generate_image_node_v2.py
@@ -2,6 +2,7 @@ import requests
 import torch
 
 from .common import (
+    bria_asset_headers,
     bria_json_headers,
     image_to_base64,
     normalize_images_input,
@@ -145,7 +146,10 @@ class GenerateImageNodeV2:
                 structured_prompt_result = result.get("structured_prompt", "")
                 used_seed = result.get("seed", seed_values[idx])
 
-                image_response = requests.get(result_image_url)
+                image_response = requests.get(
+                    result_image_url,
+                    headers=bria_asset_headers(),
+                )
                 result_image = postprocess_image(image_response.content)
 
                 batch_results.append(result_image)

--- a/nodes/generative_fill_node.py
+++ b/nodes/generative_fill_node.py
@@ -5,6 +5,7 @@ import io
 import torch
 
 from .common import (
+    bria_asset_headers,
     bria_json_headers,
     image_to_base64,
     poll_status_until_completed,
@@ -87,7 +88,10 @@ class GenFillNode():
                 
                 final_response = poll_status_until_completed(status_url, api_key)                
                 result_image_url = final_response['result']['image_url']
-                image_response = requests.get(result_image_url)
+                image_response = requests.get(
+                    result_image_url,
+                    headers=bria_asset_headers(),
+                )
                 result_image = Image.open(io.BytesIO(image_response.content))
                 result_image = result_image.convert("RGB")
                 result_image = np.array(result_image).astype(np.float32) / 255.0

--- a/nodes/image_enhance_node.py
+++ b/nodes/image_enhance_node.py
@@ -5,6 +5,7 @@ from PIL import Image
 import torch
 
 from .common import (
+    bria_asset_headers,
     bria_json_headers,
     image_to_base64,
     normalize_images_input,
@@ -90,7 +91,10 @@ class ImageEnhanceNode():
                 used_seed = final_response["result"].get("seed", seed)
 
                 # Download and process image
-                image_response = requests.get(result_image_url)
+                image_response = requests.get(
+                    result_image_url,
+                    headers=bria_asset_headers(),
+                )
                 result_image = Image.open(io.BytesIO(image_response.content)).convert("RGB")
                 result_array = np.array(result_image).astype(np.float32) / 255.0
                 result_tensor = torch.from_numpy(result_array)  # shape: (H,W,C)

--- a/nodes/image_expansion_node.py
+++ b/nodes/image_expansion_node.py
@@ -5,6 +5,7 @@ from PIL import Image
 import torch
 
 from .common import (
+    bria_asset_headers,
     bria_json_headers,
     image_to_base64,
     normalize_images_input,
@@ -119,7 +120,10 @@ class ImageExpansionNode():
                 final_response = poll_status_until_completed(status_url, api_key)
                 result_image_url = final_response["result"]["image_url"]
 
-                image_response = requests.get(result_image_url)
+                image_response = requests.get(
+                    result_image_url,
+                    headers=bria_asset_headers(),
+                )
                 result_image = Image.open(io.BytesIO(image_response.content)).convert("RGB")
                 result_tensor = torch.from_numpy(np.array(result_image).astype(np.float32) / 255.0)
 

--- a/nodes/product_integrate_node.py
+++ b/nodes/product_integrate_node.py
@@ -2,6 +2,7 @@ import requests
 import torch
 
 from .common import (
+    bria_asset_headers,
     bria_json_headers,
     image_to_base64,
     poll_status_until_completed,
@@ -121,7 +122,10 @@ class ProductIntegrateNode:
                 result_image_url = result.get("image_url")
                 used_seed = result.get("seed", seed)
 
-                image_response = requests.get(result_image_url)
+                image_response = requests.get(
+                    result_image_url,
+                    headers=bria_asset_headers(),
+                )
                 result_image = postprocess_image(image_response.content)
 
                 return (result_image, used_seed)

--- a/nodes/refine_image_lite_node_v2.py
+++ b/nodes/refine_image_lite_node_v2.py
@@ -1,6 +1,11 @@
 import requests
 
-from .common import bria_json_headers, poll_status_until_completed, postprocess_image
+from .common import (
+    bria_asset_headers,
+    bria_json_headers,
+    poll_status_until_completed,
+    postprocess_image,
+)
 
 
 
@@ -154,7 +159,10 @@ class RefineImageLiteNodeV2:
                     structured_prompt = result.get("structured_prompt", "")
                     used_seed = result.get("seed")
 
-                    image_response = requests.get(result_image_url)
+                    image_response = requests.get(
+                        result_image_url,
+                        headers=bria_asset_headers(),
+                    )
                     result_image = postprocess_image(image_response.content)
 
                     return (result_image, structured_prompt, used_seed)

--- a/nodes/refine_image_node_v2.py
+++ b/nodes/refine_image_node_v2.py
@@ -1,6 +1,11 @@
 import requests
 
-from .common import bria_json_headers, poll_status_until_completed, postprocess_image
+from .common import (
+    bria_asset_headers,
+    bria_json_headers,
+    poll_status_until_completed,
+    postprocess_image,
+)
 
 
 class RefineImageNodeV2:
@@ -156,7 +161,10 @@ class RefineImageNodeV2:
                     structured_prompt = result.get("structured_prompt", "")
                     used_seed = result.get("seed")
 
-                    image_response = requests.get(result_image_url)
+                    image_response = requests.get(
+                        result_image_url,
+                        headers=bria_asset_headers(),
+                    )
                     result_image = postprocess_image(image_response.content)
 
                     return (result_image, structured_prompt, used_seed)

--- a/nodes/reimagine_node.py
+++ b/nodes/reimagine_node.py
@@ -1,6 +1,7 @@
 import requests
 
 from .common import (
+    bria_asset_headers,
     bria_json_headers,
     image_to_base64,
     postprocess_image,
@@ -67,7 +68,10 @@ class ReimagineNode():
         )
         if response.status_code == 200:
                 response_dict = response.json()
-                image_response = requests.get(response_dict['result'][0]["urls"][0])
+                image_response = requests.get(
+                    response_dict['result'][0]["urls"][0],
+                    headers=bria_asset_headers(),
+                )
                 result_image = postprocess_image(image_response.content)
                 return (result_image,)
         else:

--- a/nodes/remove_foreground_node.py
+++ b/nodes/remove_foreground_node.py
@@ -5,6 +5,7 @@ from PIL import Image
 import torch
 
 from .common import (
+    bria_asset_headers,
     bria_json_headers,
     image_to_base64,
     normalize_images_input,
@@ -74,7 +75,10 @@ class RemoveForegroundNode():
                 result_image_url = final_response["result"]["image_url"]
 
                 # Download result
-                image_response = requests.get(result_image_url)
+                image_response = requests.get(
+                    result_image_url,
+                    headers=bria_asset_headers(),
+                )
                 result_image = Image.open(io.BytesIO(image_response.content)).convert("RGB")
 
                 # Convert to float32 tensor (H, W, C)

--- a/nodes/replace_bg_node.py
+++ b/nodes/replace_bg_node.py
@@ -5,6 +5,7 @@ from PIL import Image
 import torch
 
 from .common import (
+    bria_asset_headers,
     bria_json_headers,
     image_to_base64,
     normalize_images_input,
@@ -108,7 +109,10 @@ class ReplaceBgNode():
                 final_response = poll_status_until_completed(status_url, api_key)
                 result_image_url = final_response["result"]["image_url"]
 
-                image_response = requests.get(result_image_url)
+                image_response = requests.get(
+                    result_image_url,
+                    headers=bria_asset_headers(),
+                )
                 result_image = Image.open(io.BytesIO(image_response.content)).convert("RGB")
                 result_tensor = torch.from_numpy(np.array(result_image).astype(np.float32) / 255.0)
 

--- a/nodes/rmbg_node.py
+++ b/nodes/rmbg_node.py
@@ -5,6 +5,7 @@ from PIL import Image
 import torch
 
 from .common import (
+    bria_asset_headers,
     bria_json_headers,
     image_to_base64,
     normalize_images_input,
@@ -71,7 +72,10 @@ class RmbgNode():
                 result_image_url = final_response['result']['image_url']
 
                 # Download result
-                image_response = requests.get(result_image_url)
+                image_response = requests.get(
+                    result_image_url,
+                    headers=bria_asset_headers(),
+                )
                 result_image = Image.open(io.BytesIO(image_response.content))
 
                 # Convert to float32 tensor (H, W, C), 0-1

--- a/nodes/tailored_gen_node.py
+++ b/nodes/tailored_gen_node.py
@@ -1,6 +1,7 @@
 import requests
 
 from .common import (
+    bria_asset_headers,
     bria_json_headers,
     image_to_base64,
     postprocess_image,
@@ -82,7 +83,10 @@ class TailoredGenNode():
         )
         if response.status_code == 200:
                 response_dict = response.json()
-                image_response = requests.get(response_dict['result'][0]["urls"][0])
+                image_response = requests.get(
+                    response_dict['result'][0]["urls"][0],
+                    headers=bria_asset_headers(),
+                )
                 result_image = postprocess_image(image_response.content)
                 return (result_image,)
         else:

--- a/nodes/tailored_portrait_node.py
+++ b/nodes/tailored_portrait_node.py
@@ -5,6 +5,7 @@ from PIL import Image
 import torch
 
 from .common import (
+    bria_asset_headers,
     bria_json_headers,
     image_to_base64,
     normalize_images_input,
@@ -70,7 +71,10 @@ class TailoredPortraitNode():
                     raise Exception(f"API request failed with status {response.status_code}: {response.text}")
 
                 response_dict = response.json()
-                image_response = requests.get(response_dict["image_res"])
+                image_response = requests.get(
+                    response_dict["image_res"],
+                    headers=bria_asset_headers(),
+                )
                 result_image = Image.open(io.BytesIO(image_response.content)).convert("RGB")
 
                 # Convert to float32 tensor (H,W,C), 0-1

--- a/nodes/text_2_image_base_node.py
+++ b/nodes/text_2_image_base_node.py
@@ -1,6 +1,7 @@
 import requests
 
 from .common import (
+    bria_asset_headers,
     bria_json_headers,
     image_to_base64,
     postprocess_image,
@@ -92,7 +93,10 @@ class Text2ImageBaseNode():
         )
         if response.status_code == 200:
                 response_dict = response.json()
-                image_response = requests.get(response_dict['result'][0]["urls"][0])
+                image_response = requests.get(
+                    response_dict['result'][0]["urls"][0],
+                    headers=bria_asset_headers(),
+                )
                 result_image = postprocess_image(image_response.content)
                 return (result_image,)
         else:

--- a/nodes/text_2_image_fast_node.py
+++ b/nodes/text_2_image_fast_node.py
@@ -1,6 +1,7 @@
 import requests
 
 from .common import (
+    bria_asset_headers,
     bria_json_headers,
     image_to_base64,
     postprocess_image,
@@ -85,7 +86,10 @@ class Text2ImageFastNode():
         )
         if response.status_code == 200:
                 response_dict = response.json()
-                image_response = requests.get(response_dict['result'][0]["urls"][0])
+                image_response = requests.get(
+                    response_dict['result'][0]["urls"][0],
+                    headers=bria_asset_headers(),
+                )
                 result_image = postprocess_image(image_response.content)
                 return (result_image,)
         else:

--- a/nodes/text_2_image_hd_node.py
+++ b/nodes/text_2_image_hd_node.py
@@ -1,6 +1,6 @@
 import requests
 
-from .common import bria_json_headers, postprocess_image
+from .common import bria_asset_headers, bria_json_headers, postprocess_image
 
 
 class Text2ImageHDNode():
@@ -56,7 +56,10 @@ class Text2ImageHDNode():
         )
         if response.status_code == 200:
                 response_dict = response.json()
-                image_response = requests.get(response_dict['result'][0]["urls"][0])
+                image_response = requests.get(
+                    response_dict['result'][0]["urls"][0],
+                    headers=bria_asset_headers(),
+                )
                 result_image = postprocess_image(image_response.content)
                 return (result_image,)
         else:

--- a/nodes/utils/shot_utils.py
+++ b/nodes/utils/shot_utils.py
@@ -1,6 +1,7 @@
 import requests
 import torch
 from ..common import (
+    bria_asset_headers,
     bria_json_headers,
     image_to_base64,
     postprocess_image,
@@ -145,7 +146,10 @@ def make_api_request(api_url, payload, api_key, Placement_type = None):
                 result_images = []
                 for i, result in enumerate(response_dict.get("result", [])[:7]):
                     image_url = result[0]
-                    image_response = requests.get(image_url)
+                    image_response = requests.get(
+                        image_url,
+                        headers=bria_asset_headers(),
+                    )
                     processed = postprocess_image(image_response.content)
                     result_images.append(processed)
 
@@ -156,7 +160,10 @@ def make_api_request(api_url, payload, api_key, Placement_type = None):
 
                 return tuple(result_images)
 
-            image_response = requests.get(response_dict["result"][0][0])
+            image_response = requests.get(
+                response_dict["result"][0][0],
+                headers=bria_asset_headers(),
+            )
             result_image = postprocess_image(image_response.content)
             return (result_image,)
         else:

--- a/nodes/video_nodes/preview_video_node_from_url.py
+++ b/nodes/video_nodes/preview_video_node_from_url.py
@@ -3,6 +3,8 @@ import uuid
 import folder_paths
 import requests
 
+from ..common import bria_asset_headers
+
 class PreviewVideoURLNode:
     """
     Bria Preview Video URL Node
@@ -62,7 +64,12 @@ class PreviewVideoURLNode:
         
         # Download video from URL
         try:
-            response = requests.get(video_url, stream=True, timeout=60)
+            response = requests.get(
+                video_url,
+                stream=True,
+                timeout=60,
+                headers=bria_asset_headers(),
+            )
             response.raise_for_status()
             
             # Determine file extension from URL or Content-Type

--- a/nodes/video_nodes/video_utils.py
+++ b/nodes/video_nodes/video_utils.py
@@ -1,7 +1,7 @@
 import os
 import requests
 
-from ..common import BRIA_COMFYUI_USER_AGENT
+from ..common import BRIA_COMFYUI_USER_AGENT, bria_asset_headers
 
 
 def upload_video_to_s3(video_path, filename, api_token):
@@ -55,7 +55,8 @@ def upload_video_to_s3(video_path, filename, api_token):
         
         # Determine content type based on file extension
         upload_headers = {
-            "Content-Type": content_type
+            "Content-Type": content_type,
+            **bria_asset_headers(),
         }
 
         upload_response = requests.put(upload_url, data=video_data, headers=upload_headers)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change addresses two concerns for the ComfyUI-BRIA-API integration:

### Authentication

The codebase already authenticates to Bria’s engine using a custom **`api_token` HTTP header** (via `bria_json_headers`), not `Authorization: Bearer ...` or JWT-specific handling. There is no Bearer/JWT token type check in the repository.

### User-Agent

Previously, `User-Agent` was set to a fixed string (`bria/ComfyUI`) only where `bria_json_headers` was used. Many follow-up requests (image URL downloads, video preview fetches, S3 presigned PUT) used the default `requests` User-Agent.

This PR:

- Sets **`User-Agent` to `bria/ComfyUI-BRIA-API/<version>`**, with `<version>` from the installed `comfyui-bria-api` package metadata (falls back to `dev` when not installed as a package).
- Adds **`bria_asset_headers()`** for requests that should not send `api_token` (CDN/S3 asset GETs, arbitrary video preview URLs).
- Applies that header to **all** `requests.get` / `requests.put` paths that were missing it, including presigned S3 uploads in `video_utils.py`.

## Testing

- `python3 -m compileall -q nodes __init__.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://bria-talk.slack.com/archives/D098W339N94/p1776331371600929?thread_ts=1776331371.600929&cid=D098W339N94)

<div><a href="https://cursor.com/agents/bc-dac468f3-f138-5058-9e57-b78f3c99efb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dac468f3-f138-5058-9e57-b78f3c99efb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

